### PR TITLE
Fix escaping issue

### DIFF
--- a/utest.sh
+++ b/utest.sh
@@ -11,14 +11,14 @@ function log {
   if [[ "$flag_log" = "true" ]]; then
     time=$(date "+%H:%M:%S")
     message="[${time}] ${1}"
-    log_container="${log_container}\n${message}"
+    log_container=$(printf "%s\n%s" "$log_container" "$message")
   fi
 }
 
 function flushlog {
   if [[ "$flag_log" = "true" ]]; then
     log "Flush log to the file."
-    printf "$log_container" > utest.log
+    echo "$log_container" > utest.log
   fi
 }
 


### PR DESCRIPTION
Fix an issue where under certain circumstances (such as using
`utest --tdebug --tt "echo %inputfile" .`
as per https://github.com/styczynski/bash-universal-tester#variables ,
the error
`utest line 24: printf: ``{': invalid format character`
would occur and the `utest.log` log file would not be created correctly.